### PR TITLE
Port publiccode.yml to 0.2

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -57,7 +57,7 @@ description:
     screenshots:
       - docs/images/mainScreen.JPG
       - docs/images/feedbackDetail.JPG
-      - doc/images/thanks.JPG
+      - docs/images/thanks.JPG
 inputTypes:
   - text/plain
 outputTypes:

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: '0.1'
+publiccodeYmlVersion: '0.2'
 name: MiPiace
 releaseDate: '2019-10-27'
 url: 'https://github.com/vvfosprojects/mipiace'
@@ -33,7 +33,7 @@ localisation:
   availableLanguages:
     - it
 it:
-  countryExtensionVersion: '0.1'
+  countryExtensionVersion: '0.2'
   conforme:
     misureMinimeSicurezza: true
     gdpr: true


### PR DESCRIPTION
Ciao @supix,
questa PR:
* porta la versione del publiccode.yml alla 0.2

Rimane ancora un problema relativo alla lunghezza della `longDescription` che al momento è inferiore ai 500 caratteri.
Resto a disposizione.
Grazie!